### PR TITLE
Add Dockerfile and command-line arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.6
+
+RUN apk update \
+    && apk upgrade \
+    && apk add python py2-pip
+
+COPY . /mha
+
+RUN pip install --no-cache-dir -r /mha/requirements.txt
+
+WORKDIR /mha
+EXPOSE 8080
+CMD ["/usr/bin/python", "/mha/server.py", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ cd MHA
 pip install -r requirements.txt
 ```
 Run the development server:  
-`python server.py`
+`python server.py -d`
+
+You can change the bind address or port by specifying the appropriate options:
+`python server.py -b 0.0.0.0 -p 8080`
 
 Everything should go well, now visit [http://localhost:8080](http://localhost:8080).
+
+## Docker
+
+A `Dockerfile` is provided if you wish to build a docker image.
+
+`docker build -t mha:latest .`
+
+You can then run a container with:
+
+`docker run -d -p 8080:8080 mha:latest`
+

--- a/server.py
+++ b/server.py
@@ -15,6 +15,8 @@ from pygal.style import Style
 from IPy import IP
 import geoip2.database
 
+import argparse
+
 app = Flask(__name__)
 reader = geoip2.database.Reader(
     '%s/data/GeoLite2-Country.mmdb' % app.static_folder)
@@ -179,5 +181,12 @@ def index():
 
 
 if __name__ == '__main__':
-    app.debug = True
-    app.run(host='127.0.0.1', port=8080)
+    parser = argparse.ArgumentParser(description="Mail Header Analyser")
+    parser.add_argument("-d", "--debug", action="store_true", default=False,
+                        help="Enable debug mode")
+    parser.add_argument("-b", "--bind", default="127.0.0.1", type=str)
+    parser.add_argument("-p", "--port", default="8080", type=int)
+    args = parser.parse_args()
+
+    app.debug = args.debug
+    app.run(host=args.bind, port=args.port)


### PR DESCRIPTION
Hi,

This adds a Dockerfile for building an image based on Alpine Linux.

It also adds optional command line arguments for setting the bind address and port, and also whether or not to enable debugging. Note that these changes disable debugging by default.