### PR TITLE
Adding missing building dependecies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3-alpine
 WORKDIR /usr/src/mha
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apk add --no-cache gcc musl-dev && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY mha/ .
 


### PR DESCRIPTION
Docker fails to build the image due `geoip2` python module compilation. With this PR missing dependencies are satisfied.