### PR TITLE
add support for uploading an eml file

### DIFF
--- a/mha/server.py
+++ b/mha/server.py
@@ -84,7 +84,16 @@ def getHeaderVal(h, data, rex='\s*(.*?)\n\S+:\s'):
 @app.route('/', methods=['GET', 'POST'])
 def index():
     if request.method == 'POST':
-        mail_data = request.form['headers'].strip()
+        # fill mail data with either uploaded file or form, upload has priority
+        mail_data = ""
+        try: 
+            # if there is a file upload, read the file, and decode the binary stream
+            eml = request.files['file']
+            mail_data = eml.read().decode()
+        except Exception as e: 
+            # if anything goes wrong, revert to form
+            mail_data = request.form['headers'].strip()
+
         r = {}
         n = HeaderParser().parsestr(mail_data)
         graph = []
@@ -212,4 +221,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     app.debug = args.debug
+    app.config['UPLOAD_FOLDER']	= "."
+    app.config['MAX_CONTENT-PATH'] = 100000
     app.run(host=args.bind, port=args.port)

--- a/mha/templates/index.html
+++ b/mha/templates/index.html
@@ -180,12 +180,16 @@
         {% else %}
         <div class="row">
             <div class="col-md-12">
-                <form method="POST">
+                <form method="POST" enctype = "multipart/form-data">
                     <div class="form-group">
                         <textarea name='headers' class="form-control" rows="25" placeholder="Paste the header in here."
-                            autofocus required></textarea>
+                            autofocus></textarea>
                     </div>
-                    <button type="submit" class="btn btn-primary btn-lg btn-block">Analyze This !</button>
+                    or 
+                    <div class="form-control">
+                        <input type = "file" name = "file" />
+                    </div>
+                    <button type="sub mit" class="btn btn-primary btn-lg btn-block">Analyze This !</button>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
as I often have an .eml file at hand, I wanted to be able to upload it for analysis directly without going through copy past of header.
the file is not saved to the filesystem, and size is limited.
there is no constraint about the file type or other.
